### PR TITLE
Err413 mitigation

### DIFF
--- a/charts/local-ai/values.yaml
+++ b/charts/local-ai/values.yaml
@@ -106,6 +106,7 @@ ingress:
   enabled: false
   className: ""
   annotations:
+    {}
     # nginx.ingress.kubernetes.io/proxy-body-size: "25m" # This value determines the maxmimum uploadable file size
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"

--- a/charts/local-ai/values.yaml
+++ b/charts/local-ai/values.yaml
@@ -106,7 +106,7 @@ ingress:
   enabled: false
   className: ""
   annotations:
-    {}
+    # nginx.ingress.kubernetes.io/proxy-body-size: "25m" # This value determines the maxmimum uploadable file size
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:


### PR DESCRIPTION
it appears that there is a default proxy-body-size for nginx ingress that prevents uploads of images and audio to the api. 1 line template update to mitigate misunderstandings regarding this issue. 